### PR TITLE
ENH: add a Cython wrapper and and a C++ stub

### DIFF
--- a/evolve.cc
+++ b/evolve.cc
@@ -1,0 +1,8 @@
+#include "evolve.h"
+#include<cmath>
+
+void evolve_field(std::vector<int>& field, int num_steps)
+{
+    int L = static_cast<int>(sqrt(field.size()));
+    field[L/2] = field[L/2] == 1 ? 0 : 1;
+}

--- a/evolve.h
+++ b/evolve.h
@@ -1,0 +1,9 @@
+#ifndef __EVOLVE_FIELD__
+#define __EVOLVE_FIELD__
+
+#include<vector>
+
+void evolve_field(std::vector<int>& field, int num_steps);
+
+
+#endif

--- a/game.pyx
+++ b/game.pyx
@@ -1,0 +1,37 @@
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from numpy cimport import_array, PyArray_SimpleNewFromData, NPY_INT, npy_intp
+
+cdef extern from "evolve.cc":
+    void evolve_field(vector[int]&, int)
+
+
+
+cdef class GameField:
+    cdef vector[int] field
+    cdef int L
+    # XXX: p0, seed etc
+
+    def __init__(self, int L):
+        pass
+
+    def __cinit__(self, int L):
+        self.L = L
+        self.field.resize(L*L)
+
+        for i in range(L*L):
+            self.field[i] = 0
+
+    def get_field_array(self):
+        """Return the field as a numpy array."""
+        cdef npy_intp dims[2];
+        dims[0] = self.L 
+        dims[1] = self.L
+        return PyArray_SimpleNewFromData(2, dims, NPY_INT, &self.field[0])
+
+    def evolve(self, num_steps=1):
+        evolve_field(self.field, num_steps)
+
+#### init the numpy C API
+import_array()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup
+from Cython.Build import cythonize
+import numpy as np
+
+setup(ext_modules = cythonize(
+           ["game.pyx", "evolve.cc"],                 # our Cython source
+#           sources=["evolve.cc"],  # additional source file(s)
+           include_path = [np.get_include(),],
+           language="c++",             # generate C++ code
+      ))
+
+


### PR DESCRIPTION
Минимальная цитонная обертка и заглушка с++ кода.
Компиляция: 
```
$ python setup.py build_ext --inplace
```
Для компиляции нужен Cython и numpy (`pip install cython numpy --user`). Под виндоуз нужен также VS 2015 python tools  или community edition.
(https://blogs.msdn.microsoft.com/pythonengineering/2016/04/11/unable-to-find-vcvarsall-bat/)

Когда скомпилировалось, у Вас появилась библиотека game.so. Это питонный модуль, его можно импортировать:

```
$ ipython
Python 3.5.2 (default, Nov 17 2016, 17:05:23) 
Type 'copyright', 'credits' or 'license' for more information
IPython 6.1.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from game import GameField

In [2]: f = GameField(4)

In [3]: dir(f)
Out[3]: 
['__class__',
 '__delattr__',
 '__dir__',
 '__doc__',
 '__eq__',
 '__format__',
 '__ge__',
 '__getattribute__',
 '__gt__',
 '__hash__',
 '__init__',
 '__le__',
 '__lt__',
 '__ne__',
 '__new__',
 '__reduce__',
 '__reduce_ex__',
 '__repr__',
 '__setattr__',
 '__setstate__',
 '__sizeof__',
 '__str__',
 '__subclasshook__',
 'evolve',                            # <<<<===== here, and the next one
 'get_field_array'] 

In [4]: f.get_field_array()
Out[4]: 
array([[0, 0, 0, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0]], dtype=int32)

In [5]: f.evolve()

In [6]: f.get_field_array()
Out[6]: 
array([[0, 0, 1, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0]], dtype=int32)

In [7]: f.evolve()

In [8]: f.get_field_array()
Out[8]: 
array([[0, 0, 0, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0]], dtype=int32)
```

